### PR TITLE
Bulk Inventory Update: Pass `feedType` in query params

### DIFF
--- a/lib/walmart_seller_api/resources/feeds.rb
+++ b/lib/walmart_seller_api/resources/feeds.rb
@@ -7,14 +7,16 @@ module WalmartSellerApi
       def submit_feed(feed_type, file_path, params = {})
         path = "/v3/feeds"
         file = File.open(file_path, 'rb')
+        query = {
+          feedType: feed_type
+        }
         body = {
-          feedType: feed_type,
           file: file
         }.merge(params)
         headers = {
           'Content-Type' => 'multipart/form-data'
         }
-        post(path, body: body, headers: headers)
+        post(path, query: query, body: body, headers: headers)
       ensure
         file.close if file
       end
@@ -44,4 +46,4 @@ module WalmartSellerApi
       end
     end
   end
-end 
+end

--- a/lib/walmart_seller_api/resources/feeds.rb
+++ b/lib/walmart_seller_api/resources/feeds.rb
@@ -6,17 +6,14 @@ module WalmartSellerApi
       # Submit a new feed
       def submit_feed(feed_type, file_path, params = {})
         path = "/v3/feeds"
-        file = File.open(file_path, 'rb')
+        file = File.open(file_path)
         query = {
           feedType: feed_type
         }
         body = {
           file: file
         }.merge(params)
-        headers = {
-          'Content-Type' => 'multipart/form-data'
-        }
-        post(path, query: query, body: body, headers: headers)
+        post(path, query: query, body: body)
       ensure
         file.close if file
       end


### PR DESCRIPTION
Based on the [Walmart API documentation](https://developer.walmart.com/us-marketplace/reference/updatebulkinventory), the `feedType` should be sent as a **query parameter**, not in the request body.

We also let the HTTP client handle the `Content-Type` header so that the multipart request includes the correct boundary automatically.