### PR TITLE
Add `#update_inventory` method to `Inventory` resource

### DIFF
--- a/lib/walmart_seller_api/resources/inventory.rb
+++ b/lib/walmart_seller_api/resources/inventory.rb
@@ -1,1 +1,28 @@
- 
+# frozen_string_literal: true
+
+module WalmartSellerApi
+  module Resources
+    class Inventory < Base
+      # Updates the inventory quantity for a given SKU.
+      #
+      # @param sku [String] The SKU of the item to update.
+      # @param quantity [Integer] The quantity to set for the SKU.
+      #
+      # @see https://developer.walmart.com/us-marketplace/reference/updateinventoryforanitem-1
+      #   Walmart Marketplace Inventory API: Update inventory for an item
+      def update_inventory(sku, quantity)
+        query = build_query_params(
+          sku: sku
+        )
+        body = build_request_body(
+          sku: sku,
+          quantity: {
+            unit: 'EACH',
+            amount: quantity
+          }
+        )
+        put('/v3/inventory', query: query, body: body)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds the `#update_inventory(sku, quantity)` method to the `WalmartSellerApi::Resources::Inventory` class.
The method sends a `PUT` request to update the inventory quantity for a specific SKU, as per Walmart's [Update Inventory for an Item API](https://developer.walmart.com/us-marketplace/reference/updateinventoryforanitem-1).

The quantity is specified in `EACH` units and passed in the request body.
This supports single SKU inventory updates for the Walmart US Marketplace.