### PR TITLE
Add `#reset!` method

### DIFF
--- a/lib/walmart_seller_api.rb
+++ b/lib/walmart_seller_api.rb
@@ -28,10 +28,6 @@ module WalmartSellerApi
       @config ||= Configuration.new
     end
 
-    def client
-      @client ||= Client.new
-    end
-
     def inventory
       @inventory ||= Resources::Inventory.new(client)
     end
@@ -54,6 +50,18 @@ module WalmartSellerApi
 
     def feeds
       @feeds ||= Resources::Feeds.new(client)
+    end
+
+    def reset!
+      instance_variables.each do |ivar|
+        instance_variable_set(ivar, nil) unless ivar == :@config
+      end
+    end
+
+    private
+
+    def client
+      @client ||= Client.new
     end
   end
 end


### PR DESCRIPTION
Adds a `#reset!` method to the `WalmartSellerApi` module to allow reinitialization of the internal `@client` and its dependent resources.