### PR TITLE
Pass options to `Feeds#get_feed_status`

### DIFF
--- a/lib/walmart_seller_api/resources/feeds.rb
+++ b/lib/walmart_seller_api/resources/feeds.rb
@@ -19,9 +19,14 @@ module WalmartSellerApi
       end
 
       # Get feed status by feedId
-      def get_feed_status(feed_id)
+      def get_feed_status(feed_id, options = {})
         path = "/v3/feeds/#{feed_id}"
-        get(path)
+        query = build_query_params(
+          limit: options[:limit],
+          offset: options[:offset],
+          includeDetails: options[:include_details]
+        )
+        get(path, query: query)
       end
 
       # Get feed results by feedId


### PR DESCRIPTION
Updates the `Feeds#get_feed_status` method to accept an optional `options`. The method now supports the following query parameters:

- `limit`
- `offset`
- `includeDetails`