### PR TITLE
Update `#authenticate` to use shared request logic

### DIFF
--- a/lib/walmart_seller_api/configuration.rb
+++ b/lib/walmart_seller_api/configuration.rb
@@ -32,10 +32,21 @@ module WalmartSellerApi
       end
     end
 
+    def auth_url
+      case environment
+      when :production
+        "https://marketplace.walmartapis.com/v3/token"
+      when :sandbox
+        "https://sandbox.walmartapis.com/v3/token"
+      else
+        raise ArgumentError, "Invalid environment: #{environment}. Must be :sandbox or :production"
+      end
+    end
+
     def validate!
       raise ArgumentError, "client_id is required" if client_id.blank?
       raise ArgumentError, "client_secret is required" if client_secret.blank?
       raise ArgumentError, "Invalid environment: #{environment}" unless %i[sandbox production].include?(environment)
     end
   end
-end
+end 

--- a/lib/walmart_seller_api/configuration.rb
+++ b/lib/walmart_seller_api/configuration.rb
@@ -32,21 +32,10 @@ module WalmartSellerApi
       end
     end
 
-    def auth_url
-      case environment
-      when :production
-        "https://marketplace.walmartapis.com/v3/token"
-      when :sandbox
-        "https://sandbox.walmartapis.com/v3/token"
-      else
-        raise ArgumentError, "Invalid environment: #{environment}. Must be :sandbox or :production"
-      end
-    end
-
     def validate!
       raise ArgumentError, "client_id is required" if client_id.blank?
       raise ArgumentError, "client_secret is required" if client_secret.blank?
       raise ArgumentError, "Invalid environment: #{environment}" unless %i[sandbox production].include?(environment)
     end
   end
-end 
+end


### PR DESCRIPTION
Updates the
 `#authenticate` method to reuse the existing request handling logic (`log_request`, `log_response`, and `handle_response`) instead of parsing and error-handling manually.