### PR TITLE
Update `Orders#refund_order` to accept pre-built request body

### DIFF
--- a/lib/walmart_seller_api/resources/orders.rb
+++ b/lib/walmart_seller_api/resources/orders.rb
@@ -36,29 +36,8 @@ module WalmartSellerApi
         post(path, body: build_request_body(body))
       end
 
-      def refund_order(order_id, refund_lines)
+      def refund_order(order_id, body)
         path = "/v3/orders/#{order_id}/refund"
-        body = {
-          orderLines: refund_lines.map do |line|
-            {
-              orderLineNumber: line[:order_line_number],
-              orderLineStatuses: [
-                {
-                  status: "Refunded",
-                  statusQuantity: {
-                    amount: line[:quantity],
-                    unit: "EACH"
-                  },
-                  refund: {
-                    refundComments: line[:refund_comments],
-                    refundCharges: line[:refund_charges]
-                  }
-                }
-              ]
-            }
-          end
-        }
-
         post(path, body: build_request_body(body))
       end
 


### PR DESCRIPTION
Updates the `Orders#refund_order` method to accept a fully constructed request body instead of building it internally.