### PR TITLE
Extract error messages in an array

### DIFF
--- a/lib/walmart_seller_api/errors.rb
+++ b/lib/walmart_seller_api/errors.rb
@@ -62,10 +62,32 @@ module WalmartSellerApi
     end
 
     private_class_method def self.find_error_message(data)
-      data.dig('errors', 'error', 'description') ||
-        data["error"] ||
-        data["message"] ||
-        data["description"]
+      message = nil
+
+      [data.dig("errors", "error"), data["error"], data].each do |error|
+        message = form_error_message(error)
+        break if message.present?
+      end
+
+      message
+    end
+
+    private_class_method def self.form_error_message(error)
+      message =
+        if error.is_a?(Array)
+          error.map { |e| error_message(e) }.compact.to_sentence
+        else
+          error_message(error)
+        end
+
+      message.presence
+    end
+
+    private_class_method def self.error_message(data)
+      return data if data.is_a?(String)
+      return unless data.is_a?(Hash)
+
+      data["message"] || data["description"] || data["info"]
     end
   end
 end

--- a/spec/walmart_seller_api/api_error_spec.rb
+++ b/spec/walmart_seller_api/api_error_spec.rb
@@ -1,0 +1,240 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe WalmartSellerApi::ApiError do
+  describe '.extract_error_message' do
+    it do
+      response = {
+        'errors' => {
+          'error' => {
+            'message' => 'message',
+            'description' => 'description',
+            'info' => 'info'
+          }
+        }
+      }.to_json
+
+      message = described_class.extract_error_message(response)
+
+      expect(message).to eq('message')
+    end
+
+    it do
+      response = {
+        'errors' => {
+          'error' => {
+            'description' => 'message',
+            'info' => 'info'
+          }
+        }
+      }.to_json
+
+      message = described_class.extract_error_message(response)
+
+      expect(message).to eq('message')
+    end
+
+    it do
+      response = {
+        'errors' => {
+          'error' => {
+            'info' => 'message'
+          }
+        }
+      }.to_json
+
+      message = described_class.extract_error_message(response)
+
+      expect(message).to eq('message')
+    end
+
+    it do
+      response = {
+        'errors' => {
+          'error' => [{
+            'message' => 'message',
+            'description' => 'description',
+            'info' => 'info'
+          }]
+        }
+      }.to_json
+
+      message = described_class.extract_error_message(response)
+
+      expect(message).to eq('message')
+    end
+
+    it do
+      response = {
+        'errors' => {
+          'error' => [{
+            'description' => 'message',
+            'info' => 'info'
+          }]
+        }
+      }.to_json
+
+      message = described_class.extract_error_message(response)
+
+      expect(message).to eq('message')
+    end
+
+    it do
+      response = {
+        'errors' => {
+          'error' => [{
+            'info' => 'message'
+          }]
+        }
+      }.to_json
+
+      message = described_class.extract_error_message(response)
+
+      expect(message).to eq('message')
+    end
+
+    it do
+      response = {
+        'errors' => {
+          'error' => [{
+            'info' => 'message'
+          }, {
+            'info' => 'another message'
+          }]
+        }
+      }.to_json
+
+      message = described_class.extract_error_message(response)
+
+      expect(message).to eq('message and another message')
+    end
+
+    it do
+      response = {
+        'error' => {
+          'message' => 'message',
+          'description' => 'description',
+          'info' => 'info'
+        }
+      }.to_json
+
+      message = described_class.extract_error_message(response)
+
+      expect(message).to eq('message')
+    end
+
+    it do
+      response = {
+        'error' => {
+          'description' => 'message',
+          'info' => 'info'
+        }
+      }.to_json
+
+      message = described_class.extract_error_message(response)
+
+      expect(message).to eq('message')
+    end
+
+    it do
+      response = {
+        'error' => {
+          'info' => 'message'
+        }
+      }.to_json
+
+      message = described_class.extract_error_message(response)
+
+      expect(message).to eq('message')
+    end
+
+    it do
+      response = {
+        'error' => [{
+          'message' => 'message',
+          'description' => 'description',
+          'info' => 'info'
+        }]
+      }.to_json
+
+      message = described_class.extract_error_message(response)
+
+      expect(message).to eq('message')
+    end
+
+    it do
+      response = {
+        'error' => [{
+          'description' => 'message',
+          'info' => 'info'
+        }]
+      }.to_json
+
+      message = described_class.extract_error_message(response)
+
+      expect(message).to eq('message')
+    end
+
+    it do
+      response = {
+        'error' => [{
+          'info' => 'message'
+        }]
+      }.to_json
+
+      message = described_class.extract_error_message(response)
+
+      expect(message).to eq('message')
+    end
+
+    it do
+      response = {
+        'error' => 'message'
+      }.to_json
+
+      message = described_class.extract_error_message(response)
+
+      expect(message).to eq('message')
+    end
+
+    it do
+      response = {
+        'message' => 'message',
+        'description' => 'description',
+        'info' => 'info'
+      }.to_json
+
+      message = described_class.extract_error_message(response)
+
+      expect(message).to eq('message')
+    end
+
+    it do
+      response = {
+        'description' => 'message',
+        'info' => 'info'
+      }.to_json
+
+      message = described_class.extract_error_message(response)
+
+      expect(message).to eq('message')
+    end
+
+    it do
+      response = {
+        'info' => 'message'
+      }.to_json
+
+      message = described_class.extract_error_message(response)
+
+      expect(message).to eq('message')
+    end
+
+    it do
+      message = described_class.extract_error_message('message')
+
+      expect(message).to eq('message')
+    end
+  end
+end


### PR DESCRIPTION
When a `4xx` or `5xx` error occurs, some responses return errors inside an array, which we currently don’t handle. This change updates the error handling logic to process error messages contained within arrays.

---

<img width="1856" height="400" alt="image" src="https://github.com/user-attachments/assets/d58fcd74-068e-4fa5-a499-8dc5ed598fce" />
