### PR TITLE
Add method to list return orders

### DIFF
--- a/lib/walmart_seller_api.rb
+++ b/lib/walmart_seller_api.rb
@@ -19,6 +19,7 @@ require_relative "walmart_seller_api/resources/shipping"
 require_relative "walmart_seller_api/resources/reports"
 require_relative "walmart_seller_api/resources/feeds"
 require_relative "walmart_seller_api/resources/prices"
+require_relative "walmart_seller_api/resources/returns"
 
 module WalmartSellerApi
   class << self
@@ -56,6 +57,10 @@ module WalmartSellerApi
 
     def prices
       @prices ||= Resources::Prices.new(client)
+    end
+
+    def returns
+      @returns ||= Resources::Returns.new(client)
     end
 
     def reset!

--- a/lib/walmart_seller_api/resources/returns.rb
+++ b/lib/walmart_seller_api/resources/returns.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module WalmartSellerApi
+  module Resources
+    class Returns < Base
+      # Retrieves return orders.
+      #
+      # @param options [Hash] A hash of optional query parameters
+      # @option options [String] :return_order_id The return order ID to filter by.
+      # @option options [String] :customer_order_id The customer order ID to filter by.
+      # @option options [String] :status The return status (e.g., "INITIATED", "DELIVERED", "COMPLETED").
+      # @option options [Boolean] :replacement_info Replacement information filter.
+      # @option options [String] :return_type The type of return (e.g., "PREORDER", "REPLACEMENT", "REFUND").
+      # @option options [String] :return_creation_start_date Start date for return creation (ISO 8601 format).
+      # @option options [String] :return_creation_end_date End date for return creation (ISO 8601 format).
+      # @option options [String] :return_last_modified_start_date Start date for last modification (ISO 8601 format).
+      # @option options [String] :return_last_modified_end_date End date for last modification (ISO 8601 format).
+      # @option options [Integer] :limit Maximum number of results to return. Must not exceed 200.
+      #
+      # @return [Hash] Paginated return orders.
+      #
+      # @see https://developer.walmart.com/us-marketplace/reference/getreturns
+      def get_returns(options = {})
+        path = "/v3/returns"
+        query = build_query_params(
+          returnOrderId: options[:return_order_id],
+          customerOrderId: options[:customer_order_id],
+          status: options[:status],
+          replacementInfo: options[:replacement_info],
+          returnType: options[:return_type],
+          returnCreationStartDate: options[:return_creation_start_date],
+          returnCreationEndDate: options[:return_creation_end_date],
+          returnLastModifiedStartDate: options[:return_last_modified_start_date],
+          returnLastModifiedEndDate: options[:return_last_modified_end_date],
+          limit: options[:limit]
+        )
+        get(path, query: query)
+      end
+    end
+  end
+end

--- a/spec/walmart_seller_api_spec.rb
+++ b/spec/walmart_seller_api_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe WalmartSellerApi do
       config.client_secret = "test_client_secret"
       config.environment = :sandbox
     end
+
+    stub_request(:post, %r{/v3/token}).to_return(
+      status: 200,
+      body: {
+        'access_token' => 'access_token',
+        'expires_in' => 900
+      }.to_json
+    )
   end
 
   describe ".configure" do
@@ -16,12 +24,6 @@ RSpec.describe WalmartSellerApi do
       expect(WalmartSellerApi.config.client_id).to eq("test_client_id")
       expect(WalmartSellerApi.config.client_secret).to eq("test_client_secret")
       expect(WalmartSellerApi.config.environment).to eq(:sandbox)
-    end
-  end
-
-  describe ".client" do
-    it "returns a client instance" do
-      expect(WalmartSellerApi.client).to be_a(WalmartSellerApi::Client)
     end
   end
 
@@ -54,4 +56,172 @@ RSpec.describe WalmartSellerApi do
       expect(WalmartSellerApi.reports).to be_a(WalmartSellerApi::Resources::Reports)
     end
   end
-end 
+
+  describe ".returns" do
+    let(:returns) { described_class.returns }
+
+    describe "#get_returns" do
+      let!(:api_request) do
+        stub_request(:get, %r{/v3/returns}).to_return(
+          body: {
+            'returnOrders' => []
+          }.to_json
+        )
+      end
+
+      it "sends request with no query parameters" do
+        uri = nil
+        api_request.with do |req|
+          uri = req.uri
+        end
+
+        returns.get_returns
+
+        expect(api_request).to have_been_made.once
+
+        params = uri.query_values
+        expect(params).to be_nil
+      end
+
+      it "sets the returnOrderId query parameter" do
+        uri = nil
+        api_request.with do |req|
+          uri = req.uri
+        end
+
+        returns.get_returns(return_order_id: "value")
+
+        expect(api_request).to have_been_made.once
+
+        params = uri.query_values
+        expect(params["returnOrderId"]).to eq("value")
+      end
+
+      it "sets the customerOrderId query parameter" do
+        uri = nil
+        api_request.with do |req|
+          uri = req.uri
+        end
+
+        returns.get_returns(customer_order_id: "value")
+
+        expect(api_request).to have_been_made.once
+
+        params = uri.query_values
+        expect(params["customerOrderId"]).to eq("value")
+      end
+
+      it "sets the status query parameter" do
+        uri = nil
+        api_request.with do |req|
+          uri = req.uri
+        end
+
+        returns.get_returns(status: "value")
+
+        expect(api_request).to have_been_made.once
+
+        params = uri.query_values
+        expect(params["status"]).to eq("value")
+      end
+
+      it "sets the replacementInfo query parameter" do
+        uri = nil
+        api_request.with do |req|
+          uri = req.uri
+        end
+
+        returns.get_returns(replacement_info: "value")
+
+        expect(api_request).to have_been_made.once
+
+        params = uri.query_values
+        expect(params["replacementInfo"]).to eq("value")
+      end
+
+      it "sets the returnType query parameter" do
+        uri = nil
+        api_request.with do |req|
+          uri = req.uri
+        end
+
+        returns.get_returns(return_type: "value")
+
+        expect(api_request).to have_been_made.once
+
+        params = uri.query_values
+        expect(params["returnType"]).to eq("value")
+      end
+
+      it "sets the returnCreationStartDate query parameter" do
+        uri = nil
+        api_request.with do |req|
+          uri = req.uri
+        end
+
+        returns.get_returns(return_creation_start_date: "value")
+
+        expect(api_request).to have_been_made.once
+
+        params = uri.query_values
+        expect(params["returnCreationStartDate"]).to eq("value")
+      end
+
+      it "sets the returnCreationEndDate query parameter" do
+        uri = nil
+        api_request.with do |req|
+          uri = req.uri
+        end
+
+        returns.get_returns(return_creation_end_date: "value")
+
+        expect(api_request).to have_been_made.once
+
+        params = uri.query_values
+        expect(params["returnCreationEndDate"]).to eq("value")
+      end
+
+      it "sets the returnLastModifiedStartDate query parameter" do
+        uri = nil
+        api_request.with do |req|
+          uri = req.uri
+        end
+
+        returns.get_returns(return_last_modified_start_date: "value")
+
+        expect(api_request).to have_been_made.once
+
+        params = uri.query_values
+        expect(params["returnLastModifiedStartDate"]).to eq("value")
+      end
+
+      it "sets the returnLastModifiedEndDate query parameter" do
+        uri = nil
+        api_request.with do |req|
+          uri = req.uri
+        end
+
+        returns.get_returns(return_last_modified_end_date: "value")
+
+        expect(api_request).to have_been_made.once
+
+        params = uri.query_values
+        expect(params["returnLastModifiedEndDate"]).to eq("value")
+      end
+
+      it "sets the limit query parameter" do
+        uri = nil
+        api_request.with do |req|
+          uri = req.uri
+        end
+
+        returns.get_returns(limit: "value")
+
+        expect(api_request).to have_been_made.once
+
+        params = uri.query_values
+        expect(params["limit"]).to eq("value")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Overview

Introduces the `WalmartSellerApi::Resources::Returns` class to support retrieving return orders.

- Implements `#get_returns` to fetch return orders via `/v3/returns` endpoint.